### PR TITLE
Simplify the PPA setup in apt_repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Migrated to Github Actions for testing
-- Removed redundant `distribution` property in the `apt_repository` resource
+- Simplified the PPA setup in the `apt_repository` resource
 
 ### Added
 

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -17,10 +17,7 @@
 # limitations under the License.
 
 apt_repository 'atom-ppa' do
-  uri 'http://ppa.launchpad.net/webupd8team/atom/ubuntu'
-  components ['main']
-  keyserver 'keyserver.ubuntu.com'
-  key 'C2518248EEA14886'
+  uri 'ppa:webupd8team/atom'
 end
 
 package 'atom'


### PR DESCRIPTION
apt_repository has a simpler format just for PPAs

Signed-off-by: Tim Smith <tsmith@chef.io>